### PR TITLE
Make saveProductRelations compatible with 2.1.x

### DIFF
--- a/Model/Catalog/Product/Link.php
+++ b/Model/Catalog/Product/Link.php
@@ -26,8 +26,8 @@ class Link extends \Magento\Catalog\Model\Product\Link
         parent::saveProductRelations($product);
 
         $data = $product->getCustomtypeData();
-        if(!is_null($data)) {
-            $this->_getResource()->saveProductLinks($product, $data, self::LINK_TYPE_CUSTOMTYPE);
+        if (!is_null($data)) {
+            $this->_getResource()->saveProductLinks($product->getId(), $data, self::LINK_TYPE_CUSTOMTYPE);
         }
     }
 }


### PR DESCRIPTION
Magento\Catalog\Model\ResourceModel\Product\Link::saveProductLinks does not accept an object as first parameter anymore.

2.0.x:
```php
    /**
     * Save Product Links process
     *
     * @param \Magento\Catalog\Model\Product $product
     * @param array $data
     * @param int $typeId
     * @return $this
     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
     */
    public function saveProductLinks($product, $data, $typeId)
```

2.1.x:
```php
    /**
     * Save Product Links process
     *
     * @param int $parentId
     * @param array $data
     * @param int $typeId
     * @return $this
     * @throws \Magento\Framework\Exception\LocalizedException
     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
     */
    public function saveProductLinks($parentId, $data, $typeId)
```